### PR TITLE
Fix/simplify memory management + use googletest 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,53 @@
+cmake_minimum_required(VERSION 3.1)
+
+project(mattanTester VERSION 1.0 LANGUAGES C CXX)
+
+
+#######################################
+### SETTING UP GOOGLE TEST ###
+
+## Download and unpack googletest at configure time
+configure_file(CMakeLists.txt.in googletest-download/CMakeLists.txt)
+execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+       RESULT_VARIABLE result
+       WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
+if(result)
+   message(FATAL_ERROR "CMake step for googletest failed: ${result}")
+endif()
+execute_process(COMMAND ${CMAKE_COMMAND} --build .
+       RESULT_VARIABLE result
+       WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
+if(result)
+   message(FATAL_ERROR "Build step for googletest failed: ${result}")
+endif()
+
+# Prevent overriding the parent project's compiler/linker
+# settings on Windows
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+
+# Add googletest directly to our build. This defines
+# the gtest and gtest_main targets.
+add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/googletest-src
+       ${CMAKE_CURRENT_BINARY_DIR}/googletest-build
+       EXCLUDE_FROM_ALL)
+
+# The gtest/gtest_main targets carry header search path
+# dependencies automatically when using CMake 2.8.11 or
+# later. Otherwise we have to add them here ourselves.
+if (CMAKE_VERSION VERSION_LESS 2.8.11)
+   include_directories("${gtest_SOURCE_DIR}/include")
+endif()
+
+
+#######################################
+
+add_executable(mattanTester SampleClient.cpp)
+target_include_directories(mattanTester PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../)
+target_link_libraries(mattanTester PRIVATE MapReduceFramework gtest_main)
+
+
+set_property(TARGET mattanTester PROPERTY CXX_STANDARD 11)
+target_compile_options(mattanTester PUBLIC -Wall -Wextra)
+
+target_compile_definitions(mattanTester PUBLIC RANDOM_STRINGS_PATH="${CMAKE_CURRENT_SOURCE_DIR}/randomstring.txt")
+

--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 2.8.2)
+
+project(googletest-download NONE)
+
+include(ExternalProject)
+ExternalProject_Add(googletest
+  GIT_REPOSITORY    https://github.com/google/googletest.git
+  GIT_TAG           master
+  SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
+  BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND     ""
+  INSTALL_COMMAND   ""
+  TEST_COMMAND      ""
+)

--- a/README.md
+++ b/README.md
@@ -1,21 +1,92 @@
 # osex3basicTest
 tester for HUJI OS 2020 exercise 3
 ## Instructions:
-- substitute SampleClient.cpp in your project folder for the one in the tester folder. (If you want to use it again later then back it up by renaming it or whatever)
-- put the randomstring.txt somewhere on your disk
-- substitute the path to randomstring.txt in the PATH_TO_RANDOM_STRING variable which resides in line 10 of "SampleClient.cpp".
-- Rebuild the project. If it still runs the old executable make sure to recompile SampleClient.cpp (right click it in clion in the project context menu, and select "Recompile SampleClient.cpp")
-- Run
+
+1. Clone this repository under the `mattanTests` directory by using the following command:
+   
+   ```shell
+   cd YOUR_PROJECT_ROOT_FOLDER
+   git clone https://github.com/mattany/osex3basicTest mattanTests`
+   ```
+   
+2. Use the following `CMakeLists.txt` in your project root
+
+    ``` cmake
+
+    cmake_minimum_required(VERSION 3.1)
 
 
-### Example cmakelists.txt file:
 
-(project specific)
-```
-cmake_minimum_required(VERSION 3.12)
-project(ex3)
+    # NOTE: You can't have both ThreadSanitizer and AddressSanitizer enabled at the same time.
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -pthread")
-set(CMAKE_CXX_STANDARD 11)
-add_executable(ex3 SampleClient.cpp Barrier.cpp Barrier.h MapReduceClient.h MapReduceFramework.cpp MapReduceFramework.h)
-```
+    # Uncomment the following to enable ThreadSanitizer.
+    #set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=thread")
+    #set (CMAKE_LINKER_FLAGS_DEBUG "${CMAKE_LINKER_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=thread")
+
+    # Uncomment the following to enable AddressSanitizer.
+    #set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
+    #set (CMAKE_LINKER_FLAGS_DEBUG "${CMAKE_LINKER_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
+
+
+    # Project configuration
+    project(ex3 VERSION 1.0 LANGUAGES C CXX)
+
+
+    # Ensure system has pthreads
+    set(THREADS_PREFER_PTHREAD_FLAG ON)
+    find_package(Threads REQUIRED)
+
+    add_library(MapReduceFramework
+            MapReduceClient.h
+            MapReduceFramework.cpp MapReduceFramework.h
+    # ------------- Add your own .h/.cpp files here -------------------
+    )
+
+
+    set_property(TARGET MapReduceFramework PROPERTY CXX_STANDARD 11)
+    target_compile_options(MapReduceFramework PUBLIC -Wall -Wextra)
+    target_include_directories(MapReduceFramework PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+    # link pthreads to your framework
+    target_link_libraries(MapReduceFramework PUBLIC Threads::Threads)
+
+    # Add tests
+    add_subdirectory(mattanTests)
+
+
+    ```
+    
+    Note, do not change 'MapReduceFramework' anywhere in the above template.
+    
+    **You can enable Address Sanitizer or Thread Sanitizer(only one of them), but you will
+      fail the test `errorMessageTest`. Other tests should pass with NO MEMORY LEAKS.**
+      
+    **Valgrind is not recommended, prefer using ASan as it is much faser.**
+    
+    It is recommended that you also test your program with high optimization levels, by adding `-O2` to `target_compile_options`,
+    and to print statements in your code(if you have any), as well as asserts (by adding `-DNDEBUG`), as these things affect the program's
+    behavior and can uncover multi-threading bugs.
+
+3. If using CLion, reload the cmake project(under `File`) after doing the above, then compile(`Build | Build 'All'`)
+   Now, you can run individual tests by going to the tests source code (`YOUR_PROJECT_ROOT/mattanTests/SampleClient.cpp`), and there's a green button 
+   near each test(`TEST(...)`) that allows you to run/debug it.
+   Alternatively, right click on the entire file and you can do `Run 'All in SampleClient...'` to run all tests at once.
+   
+   
+   
+   If using terminal, do the following to compile and run. It is important
+   that you delete the cmake-build-debug whenever you change to a different system, but otherwise
+   it is not needed.
+   
+   Compile:
+   ```shell
+   cd YOUR_PROJECT_ROOT
+   rm -rf cmake-build-debug
+   mkdir cmake-build-debug
+   cd cmake-build-debug
+   cmake ..
+   make -j 4
+   ```
+   
+   And run via `YOUR_PROJECT_ROOT/cmake-build-debug/mattanTests/mattanTester --gtest_filter="-*error**` (without 'errorMessageTest',
+   supports ASan/TSan), omit the gtest_filter to run the errorMessageTest too, but note that it will fail if you have a sanitizer enabled
+   in your CMakeLists.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ tester for HUJI OS 2020 exercise 3
    
    ```shell
    cd YOUR_PROJECT_ROOT_FOLDER
-   git clone https://github.com/mattany/osex3basicTest mattanTests`
+   git clone https://github.com/mattany/osex3basicTest mattanTests
    ```
    
 2. Use the following `CMakeLists.txt` in your project root
@@ -62,7 +62,7 @@ tester for HUJI OS 2020 exercise 3
     **Valgrind is not recommended, prefer using ASan as it is much faser.**
     
     It is recommended that you also test your program with high optimization levels, by adding `-O2` to `target_compile_options`,
-    and to print statements in your code(if you have any), as well as asserts (by adding `-DNDEBUG`), as these things affect the program's
+    and to delete print statements in your code(if you have any), as well as asserts (by using `-DNDEBUG` flag), as these things affect the program's
     behavior and can uncover multi-threading bugs.
 
 3. If using CLion, reload the cmake project(under `File`) after doing the above, then compile(`Build | Build 'All'`)
@@ -86,6 +86,6 @@ tester for HUJI OS 2020 exercise 3
    make -j 4
    ```
    
-   And run via `YOUR_PROJECT_ROOT/cmake-build-debug/mattanTests/mattanTester --gtest_filter="-*error**` (without 'errorMessageTest',
+   And run via `YOUR_PROJECT_ROOT/cmake-build-debug/mattanTests/mattanTester --gtest_filter="-*error*"` (without 'errorMessageTest',
    supports ASan/TSan), omit the gtest_filter to run the errorMessageTest too, but note that it will fail if you have a sanitizer enabled
    in your CMakeLists.


### PR DESCRIPTION
First, I've changed the tests to run using the googletest framework, this makes it easy to choose specific tests in the CLion interface (or via terminal, using a regex) rather than having to comment/uncomment tests in the main function

Also, the error test now ensures that a proper message is emitted to stderr(when not using a sanitizer)

Secondly, I simplified memory management - CounterClient automatically releases the memory for
both Input,Output vectors as well as intermediate pairs. 

The program now works with Address sanitizer (I haven't checked Valgrind, but it should work too), except for the errorMessageTest (at least for me, address sanitizer terminates the program before my library manages to do so.) 